### PR TITLE
Fix for macOS build failing on Monterey (#278)

### DIFF
--- a/cmake/FindPolarSSL.cmake
+++ b/cmake/FindPolarSSL.cmake
@@ -49,6 +49,10 @@ if( ${POLARSSL_LIBRARIES-NOTFOUND} )
   return()
 endif()
 
+if( "${CMAKE_C_COMPILER}" STREQUAL "/Library/Developer/CommandLineTools/usr/bin/cc" )
+  set(CMAKE_C_COMPILER cc)
+endif()
+
 if( NOT CMAKE_CROSSCOMPILING )
   execute_process(
     COMMAND echo "#include <${POLARSSL_INC_FOLDER}/version.h>\n#include <stdio.h>\nint main(){printf(${POLARSSL_REAL_NAME}_VERSION_STRING);return 0;}"

--- a/include/dislocker/metadata/datums.h
+++ b/include/dislocker/metadata/datums.h
@@ -42,7 +42,7 @@
 /**
  * Here stand datums' value types stuff
  */
-#define NB_DATUMS_VALUE_TYPES 22
+#define NB_DATUMS_VALUE_TYPES 20
 
 enum value_types
 {
@@ -349,8 +349,6 @@ static const print_datum_f print_datum_tab[NB_DATUMS_VALUE_TYPES] =
 	print_datum_generic,
 	print_datum_generic,
 	print_datum_virtualization,
-	print_datum_generic,
-	print_datum_generic,
 	print_datum_generic,
 	print_datum_generic,
 	print_datum_generic,

--- a/src/dislocker-fuse.c
+++ b/src/dislocker-fuse.c
@@ -199,6 +199,8 @@ int main(int argc, char** argv)
 	/* Get command line options */
 	dis_ctx = dis_new();
 	param_idx = dis_getopts(dis_ctx, argc, argv);
+	if (param_idx == -1)
+		exit(EXIT_FAILURE);
 
 	/*
 	 * Check we have a volume path given and if not, take the first non-argument

--- a/src/metadata/datums.c
+++ b/src/metadata/datums.c
@@ -229,7 +229,7 @@ int get_payload_safe(void* data, void** payload, size_t* size_payload)
 	if(!get_header_safe(data, &header))
 		return FALSE;
 
-	if(header.value_type > NB_DATUMS_VALUE_TYPES)
+	if(header.value_type >= NB_DATUMS_VALUE_TYPES)
 		return FALSE;
 
 	size_header = datum_value_types_prop[header.value_type].size_header;
@@ -662,7 +662,7 @@ int get_nested_datum(void* datum, void** datum_nested)
 	if(!get_header_safe(datum, &header))
 		return FALSE;
 
-	if(header.value_type > NB_DATUMS_VALUE_TYPES)
+	if(header.value_type >= NB_DATUMS_VALUE_TYPES)
 		return FALSE;
 
 	if(!datum_value_types_prop[header.value_type].has_nested_datum)


### PR DESCRIPTION
Fixed an issue in cmake/FindPolarSSL.cmake where the system's C compiler would be called directly without the shim to provide access to standard system libraries. With this fix, building on macOS no longer fails to find stdio.h ;) and building dislocker is successful